### PR TITLE
Centralize supabase client

### DIFF
--- a/Scripts/generateMatches.js
+++ b/Scripts/generateMatches.js
@@ -1,21 +1,10 @@
 import fetch from 'cross-fetch';
 globalThis.fetch = fetch;
-import dotenv from 'dotenv';
-import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+import { supabase } from '../src/supabaseClient.js';
 import lodash from 'lodash';
-
-dotenv.config();
 const { shuffle } = lodash;
 
-const SUPABASE_URL = process.env.REACT_APP_SUPABASE_URL;
-const SUPABASE_KEY = process.env.REACT_APP_SUPABASE_KEY;
-
-if (!SUPABASE_URL || !SUPABASE_KEY) {
-  console.error('❌ Supabase-Umgebungsvariablen fehlen. Bitte prüfe deine .env-Datei.');
-  process.exit(1);
-}
-
-const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
 // Liste der Teilnehmer:innen
 const PARTICIPANTS = [

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -1,10 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
+import { supabase } from '../supabaseClient';
 
 export default function Leaderboard() {
   const [scores, setScores] = useState([]);

--- a/src/pages/PlayerMatches.jsx
+++ b/src/pages/PlayerMatches.jsx
@@ -1,12 +1,7 @@
 // src/pages/PlayerMatches.jsx
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
+import { supabase } from '../supabaseClient';
 
 export default function PlayerMatches() {
   const { name } = useParams();

--- a/src/pages/PlayerSelect.jsx
+++ b/src/pages/PlayerSelect.jsx
@@ -1,12 +1,7 @@
 // src/pages/PlayerSelect.jsx
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
+import { supabase } from '../supabaseClient';
 
 export default function PlayerSelect() {
   const [players, setPlayers] = useState([]);

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,7 +1,19 @@
 // src/supabaseClient.js
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://ckgpwsgsjmtdoipnerch.supabase.com';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNrZ3B3c2dzam10ZG9pcG5lcmNoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg1NTc1OTksImV4cCI6MjA2NDEzMzU5OX0.Dbt6OnjcPSw8Xuw3AwVa8683PcfsKkSyhZgTvxTP8Dk';
+// Prefer REACT_APP_* for CRA, fall back to VITE_*, and support import.meta.env
+const supabaseUrl =
+  process.env.REACT_APP_SUPABASE_URL ||
+  process.env.VITE_SUPABASE_URL ||
+  (typeof import.meta !== 'undefined' ? import.meta.env.VITE_SUPABASE_URL : undefined);
+
+const supabaseAnonKey =
+  process.env.REACT_APP_SUPABASE_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  (typeof import.meta !== 'undefined' ? import.meta.env.VITE_SUPABASE_ANON_KEY : undefined);
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Supabase environment variables are missing');
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- load Supabase credentials from env variables in `supabaseClient.js`
- reuse that client in components and generate script

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684959007a3c832bbf6dfd530c1896f1