### PR TITLE
Fix duplicate navigation links

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link, Outlet } from 'react-router-dom';
-import { Link } from 'react-router-dom';
 
 
 const Layout = () => {
@@ -9,10 +8,8 @@ const Layout = () => {
       <nav style={{ marginBottom: '20px' }}>
         <Link to="/">🏠 Home</Link> |{' '}
         <Link to="/input">📥 Ergebnisse</Link> |{' '}
-        <Link to="/leaderboard">📊 Punktestand</Link>
-        <Link to="/">Start</Link> |{' '}
-  <Link to="/leaderboard">Leaderboard</Link> |{' '}
-  <Link to="/rules">Regelwerk</Link>
+        <Link to="/leaderboard">📊 Punktestand</Link> |{' '}
+        <Link to="/rules">Regelwerk</Link>
       </nav>
       <Outlet />
     </div>


### PR DESCRIPTION
## Summary
- remove duplicate Link import in `Layout.jsx`
- consolidate navigation links to list each route once

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684958fe923c832bbeeb5f6c798cfef8